### PR TITLE
Fix human expression of log operator

### DIFF
--- a/src/operator.hpp
+++ b/src/operator.hpp
@@ -270,7 +270,7 @@ struct Log : Fun {
   }
 
   string human_repr(vector<string> & args) override {
-    return "sqrt(max(1.0,"+args[0]+"))";
+    return "log(max(1.0,"+args[0]+"))";
   }
 
 };


### PR DESCRIPTION
Seems like the `human_repr` for the Log operator contains a typo, possibly due to copy pasting the Sqrt operator.