### PR TITLE
Fixed batching logic to sample from all training instances

### DIFF
--- a/src/fitness.hpp
+++ b/src/fitness.hpp
@@ -92,7 +92,8 @@ struct Fitness {
     }
     
     // else pick some random elements
-    auto chosen = Rng::rand_perm(num_observations);
+    auto chosen = Rng::rand_perm(n);
+    chosen.resize(num_observations);
     this->X_batch = X_train(chosen, Eigen::all);
     this->y_batch = y_train(chosen);
     return true;


### PR DESCRIPTION
The previous index set (`auto chosen = Rng::rand_perm(num_observations);`) only uses the first `batch_size` instance indices (in a random order), instead of randomly choosing `batch_size` indices from all training instances.